### PR TITLE
Expose underlying MerlinProcess Instance.

### DIFF
--- a/pkg/nuclide/ocaml-base/lib/LocalMerlinService.js
+++ b/pkg/nuclide/ocaml-base/lib/LocalMerlinService.js
@@ -48,3 +48,8 @@ export async function complete(
   const instance = await getInstance(path);
   return instance ? instance.complete(path, line, col, prefix) : null;
 }
+
+export async function getInstanceForPath(path: NuclideUri): Promise<?any> {
+  return await getInstance(path);
+}
+


### PR DESCRIPTION
This is useful when needing to debug/prototype on custom merlin versions. (I'm currently using a cutting edge branch of merlin that won't get Nuclide support for quite some time and this hook is very useful).
